### PR TITLE
Support browser-native dark mode

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -11,9 +11,12 @@ input::-webkit-inner-spin-button {
 input[type=number] {
   appearance: textfield;
 }
+:root {
+  color-scheme: light dark;
+}
 @layer base{
   a {
-    color:blue
+    color: light-dark(blue, cyan)
   }
   a:hover{
     color:dodgerblue

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="light dark">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
A `color-scheme` declaration with `light dark` is enough to indicate to browsers that both are supported and for browsers to use user and system preference to render one or the other through browser default stylesheets.

https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

---

Screenshot of lemvotes.org with the header added:

![](https://github.com/user-attachments/assets/6cee433a-03d3-4e75-88e5-57bdf02f63c0)
